### PR TITLE
fix fc indicator/streak breaking in setlists

### DIFF
--- a/_ark/ui/track_panel.dta
+++ b/_ark/ui/track_panel.dta
@@ -6,9 +6,6 @@
    DX_TRACK_TEXTURE_HANDLER
       {game add_sink $this}
 
-      #ifndef HX_EE ; why does this not work on ps2
-      DX_CALLBACK_SETUP
-      #endif
       DX_SET_TRACK_SPEED
       {$this
          set_showing
@@ -66,7 +63,11 @@
          {synth play track_beg.cue}
 		 {unless {> {gamecfg get practice_speed} 0} {beatmatch set_music_speed $speedmod}}
 		 {if {> {gamecfg get practice_speed} 0} {beatmatch set_music_speed $modifier}}}
-       #ifndef HX_EE DX_FC_SETUP #endif))
+       #ifndef HX_EE
+       DX_CALLBACK_SETUP
+       DX_FC_SETUP
+       #endif
+       ))
 {new
    TrackPanel
    coop_track_panel


### PR DESCRIPTION
adds the callbacks in on_extend instead of enter

actions will fail due to them using an obsolete version