### PR TITLE
Missing GH2 token added, etc (read)

### DIFF
--- a/_ark/dx/song_updates/metadata_updates.dta
+++ b/_ark/dx/song_updates/metadata_updates.dta
@@ -461,6 +461,7 @@
 (UGC_5000988 (name "If Trucks Drank Beer (ft. CJ Watson)") (artist "Error 404"))
 (UGC_5000990 (name "Little Black Backpack") (year_recorded 2009))
 (UGC_5000993 (name "Kick Some Ass") (year_recorded 2009))
+(UGC_5000101 (game_origin ugc_lost))
 (UGC_5001156 (name "Race the Hourglass"))
 (UGC_5001319 (genre alternative))
 (UGC_5001352 (genre prog))

--- a/_ark/dx/song_updates/official_additional_metadata.dta
+++ b/_ark/dx/song_updates/official_additional_metadata.dta
@@ -1578,7 +1578,7 @@
 (whenicomearound (author "Harmonix"))
 
 ; Rock Band 3 Beta
-(blackmagicgypsyqueen (author "Harmonix"))
+(blackmagicgypsyqueen (game_origin rb3dlc) (author "Harmonix"))
 (feelinalright (author "Harmonix"))
 
 ; Rock Band 3

--- a/_ark/ui/eng/locale_updates.dta
+++ b/_ark/ui/eng/locale_updates.dta
@@ -34,6 +34,7 @@
 (fnfestival "Fortnite Festival")
 (onyxite "Onyxite Charts")
 (gh1 "Guitar Hero")
+(gh2 "Guitar Hero II")
 (gh2dx "Guitar Hero II Deluxe")
 (gh2dxdlc "Guitar Hero Rocks the 360")
 (gh80sdx "Guitar Hero Encore Deluxe")


### PR DESCRIPTION
Talking In Your Sleep gets `ugc_lost` token, blackmagicgypsyqueen gets `rb3dlc` token